### PR TITLE
Fix sorting by GitHub stars

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -398,23 +398,7 @@ widgets:
     short: >
       ggstatsplot provides a collection of functions to enhance ggplot2 plots with results from statistical tests.
     description: >
-        
- -
-    name: ggstatsplot
-    thumbnail: images/ggstatsplot.png
-    url: https://github.com/IndrajeetPatil/ggstatsplot
-    jslibs: >
-    ghuser: IndrajeetPatil
-    ghrepo: ggstatsplot
-    tags: visualization,statistics
-    cran: false
-    release:
-    examples:
-    ghauthor: IndrajeetPatil
-    short: >
-      The ggstatsplot provides a way to build 'ggplot2' plot with statistical details.
-    description: >
-        
+
  -
     name: ggnetwork
     thumbnail: images/ggnetwork.png

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -110,7 +110,9 @@
           </div>
           <div class="card-content widget-content">
             <a href="{{ widget.url }}"><span class="card-title grey-text text-darken-4">{{ widget.name }}</span></a>
-            <span class="github-btn github-watchers" data-processed="1"><a class="gh-btn" href="https://github.com/{{ widget.ghuser }}/{{ widget.ghrepo }}/" target="_blank"><span class="gh-ico"></span><span class="gh-text">Star</span></a><a class="gh-count" id="{{ widget.ghuser }}_{{ widget.ghrepo }}" href="https://github.com/{{ widget.ghuser }}/{{ widget.ghrepo }}/stargazers" target="_blank" style="display: block;"></a></span>
+            {% if widget.ghuser != null %}
+            <span class="github-btn github-watchers" data-processed="1"><a class="gh-btn" href="https://github.com/{{ widget.ghuser }}/{{ widget.ghrepo }}/" target="_blank"><span class="gh-ico"></span><span class="gh-text">Star</span></a><a class="gh-count" id="{{ widget.name }}_stars" href="https://github.com/{{ widget.ghuser }}/{{ widget.ghrepo }}/stargazers" target="_blank" style="display: block;"></a></span>
+            {% endif %}
             <p class="widget-shortdesc">{{ widget.short | markdownify | remove: '<p>' | remove: '</p>' }}</p>
             <p class="widget-list-item"><i class="material-icons meta-bullet red-text">stop</i><span class="red-text">author:</span> <span class="widget-author widget-meta"><a href="https://github.com/{{ widget.ghauthor }}">{{ widget.ghauthor }}</a></span></p>
             <p class="widget-list-item"><i class="material-icons meta-bullet green-text">stop</i><span class="green-text">tags:</span> <span class="widget-tags widget-meta">{{ widget.tags }}</span></p>

--- a/github_meta.json
+++ b/github_meta.json
@@ -1,1 +1,254 @@
-{"ggjoy":{"stargazers_count":256,"open_issues_count":0,"forks_count":16,"watchers_count":14}, "ggExtra":{"stargazers_count":91,"open_issues_count":7,"forks_count":26,"watchers_count":12}}
+{
+  "ggQQunif_stars": {
+    "stargazers_count": 0,
+    "open_issues_count": 0,
+    "forks_count": 0,
+    "watchers_count": 0
+  },
+  "xmrr_stars": {
+    "stargazers_count": 1,
+    "open_issues_count": 1,
+    "forks_count": 0,
+    "watchers_count": 1
+  },
+  "gg3D_stars": {
+    "stargazers_count": 50,
+    "open_issues_count": 2,
+    "forks_count": 5,
+    "watchers_count": 50
+  },
+  "ggQC_stars": {
+    "stargazers_count": 26,
+    "open_issues_count": 1,
+    "forks_count": 7,
+    "watchers_count": 26
+  },
+  "ggedit_stars": {
+    "stargazers_count": 171,
+    "open_issues_count": 0,
+    "forks_count": 24,
+    "watchers_count": 171
+  },
+  "ggforce_stars": {
+    "stargazers_count": 324,
+    "open_issues_count": 51,
+    "forks_count": 40,
+    "watchers_count": 324
+  },
+  "ggalt_stars": {
+    "stargazers_count": 405,
+    "open_issues_count": 25,
+    "forks_count": 59,
+    "watchers_count": 405
+  },
+  "ggiraph_stars": {
+    "stargazers_count": 301,
+    "open_issues_count": 8,
+    "forks_count": 39,
+    "watchers_count": 301
+  },
+  "ggmuller_stars": {
+    "stargazers_count": 46,
+    "open_issues_count": 1,
+    "forks_count": 2,
+    "watchers_count": 46
+  },
+  "ggstance_stars": {
+    "stargazers_count": 152,
+    "open_issues_count": 3,
+    "forks_count": 13,
+    "watchers_count": 152
+  },
+  "ggrepel_stars": {
+    "stargazers_count": 577,
+    "open_issues_count": 23,
+    "forks_count": 70,
+    "watchers_count": 577
+  },
+  "ggraph_stars": {
+    "stargazers_count": 598,
+    "open_issues_count": 59,
+    "forks_count": 69,
+    "watchers_count": 598
+  },
+  "geomnet_stars": {
+    "stargazers_count": 50,
+    "open_issues_count": 5,
+    "forks_count": 10,
+    "watchers_count": 50
+  },
+  "ggExtra_stars": {
+    "stargazers_count": 176,
+    "open_issues_count": 11,
+    "forks_count": 38,
+    "watchers_count": 176
+  },
+  "ggfortify_stars": {
+    "stargazers_count": 382,
+    "open_issues_count": 14,
+    "forks_count": 53,
+    "watchers_count": 382
+  },
+  "autoplotly_stars": {
+    "stargazers_count": 35,
+    "open_issues_count": 0,
+    "forks_count": 0,
+    "watchers_count": 35
+  },
+  "gganimate_stars": {
+    "stargazers_count": 1120,
+    "open_issues_count": 49,
+    "forks_count": 193,
+    "watchers_count": 1120
+  },
+  "plotROC_stars": {
+    "stargazers_count": 54,
+    "open_issues_count": 8,
+    "forks_count": 13,
+    "watchers_count": 54
+  },
+  "ggthemes_stars": {
+    "stargazers_count": 958,
+    "open_issues_count": 5,
+    "forks_count": 191,
+    "watchers_count": 958
+  },
+  "ggstatsplot_stars": {
+    "stargazers_count": 366,
+    "open_issues_count": 10,
+    "forks_count": 45,
+    "watchers_count": 366
+  },
+  "ggnetwork_stars": {
+    "stargazers_count": 65,
+    "open_issues_count": 24,
+    "forks_count": 25,
+    "watchers_count": 65
+  },
+  "ggtech_stars": {
+    "stargazers_count": 211,
+    "open_issues_count": 2,
+    "forks_count": 44,
+    "watchers_count": 211
+  },
+  "ggradar_stars": {
+    "stargazers_count": 132,
+    "open_issues_count": 8,
+    "forks_count": 55,
+    "watchers_count": 132
+  },
+  "ggTimeSeries_stars": {
+    "stargazers_count": 155,
+    "open_issues_count": 3,
+    "forks_count": 32,
+    "watchers_count": 155
+  },
+  "ggtree_stars": {
+    "stargazers_count": 297,
+    "open_issues_count": 32,
+    "forks_count": 82,
+    "watchers_count": 297
+  },
+  "ggseas_stars": {
+    "stargazers_count": 49,
+    "open_issues_count": 4,
+    "forks_count": 5,
+    "watchers_count": 49
+  },
+  "ggsci_stars": {
+    "stargazers_count": 162,
+    "open_issues_count": 1,
+    "forks_count": 25,
+    "watchers_count": 162
+  },
+  "ggmosaic_stars": {
+    "stargazers_count": 61,
+    "open_issues_count": 12,
+    "forks_count": 8,
+    "watchers_count": 61
+  },
+  "survminer_stars": {
+    "stargazers_count": 172,
+    "open_issues_count": 75,
+    "forks_count": 59,
+    "watchers_count": 172
+  },
+  "ggthemr_stars": {
+    "stargazers_count": 485,
+    "open_issues_count": 3,
+    "forks_count": 71,
+    "watchers_count": 485
+  },
+  "GGally_stars": {
+    "stargazers_count": 276,
+    "open_issues_count": 20,
+    "forks_count": 89,
+    "watchers_count": 276
+  },
+  "ggseqlogo_stars": {
+    "stargazers_count": 89,
+    "open_issues_count": 8,
+    "forks_count": 8,
+    "watchers_count": 89
+  },
+  "ggChernoff_stars": {
+    "stargazers_count": 21,
+    "open_issues_count": 0,
+    "forks_count": 2,
+    "watchers_count": 21
+  },
+  "ggridges_stars": {
+    "stargazers_count": 220,
+    "open_issues_count": 11,
+    "forks_count": 16,
+    "watchers_count": 220
+  },
+  "lemons_stars": {
+    "stargazers_count": 82,
+    "open_issues_count": 4,
+    "forks_count": 4,
+    "watchers_count": 82
+  },
+  "cowplot_stars": {
+    "stargazers_count": 354,
+    "open_issues_count": 8,
+    "forks_count": 62,
+    "watchers_count": 354
+  },
+  "qqplotr_stars": {
+    "stargazers_count": 27,
+    "open_issues_count": 1,
+    "forks_count": 2,
+    "watchers_count": 27
+  },
+  "ggalluvial_stars": {
+    "stargazers_count": 143,
+    "open_issues_count": 7,
+    "forks_count": 10,
+    "watchers_count": 143
+  },
+  "patchwork_stars": {
+    "stargazers_count": 962,
+    "open_issues_count": 29,
+    "forks_count": 69,
+    "watchers_count": 962
+  },
+  "ggquiver_stars": {
+    "stargazers_count": 20,
+    "open_issues_count": 0,
+    "forks_count": 2,
+    "watchers_count": 20
+  },
+  "ggdag_stars": {
+    "stargazers_count": 138,
+    "open_issues_count": 1,
+    "forks_count": 6,
+    "watchers_count": 138
+  },
+  "ggformula_stars": {
+    "stargazers_count": 15,
+    "open_issues_count": 20,
+    "forks_count": 1,
+    "watchers_count": 15
+  }
+}

--- a/js/grid.js
+++ b/js/grid.js
@@ -64,6 +64,10 @@ $( function() {
       },
       stars: function( itemElem ) {
         var stars = -parseInt($( itemElem ).find(".gh-count").html());
+        // if the package is not on github, return 0
+        if (isNaN(stars)) {
+          return 0;
+        }
         return stars;
       }
     },


### PR DESCRIPTION
Fix #3 

Some packages are not on GitHub, but the current code seems not handle them well, which seems the reason why the sorting won't work.

This PR tweaks code so that it

* skips adding stars to non-GitHub packages and
* uses 0 `stargazers_count` for sorting non-GitHub packages

result: https://yutannihilation.github.io/ggplot2-exts-gallery/