### PR TITLE
fix typo in ggnewscale

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1444,7 +1444,7 @@ widgets:
       This package uses Self-Organizing Map to data dimensionality reduction. Use geom_class() to visualization in parallelel coordinates each neuron of the Self-Organizing Maps.
 
  -
-    name: ggnewsccale
+    name: ggnewscale
     thumbnail: images/ggnewscale.png
     url: https://github.com/eliocamp/ggnewscale
     jslibs: >


### PR DESCRIPTION
Just a small typo in the name of the package